### PR TITLE
Add page argument to url for complete routing information

### DIFF
--- a/templates/frontend/objects/issue_toc.tpl
+++ b/templates/frontend/objects/issue_toc.tpl
@@ -58,7 +58,7 @@
 		<section class="row issue-desc">
 			{assign var=issueCover value=$issue->getLocalizedCoverImageUrl()}
 			{if $issueCover}
-				<a class="col-md-2" href="{url op="view" path=$issue->getBestIssueId()}">
+				<a class="col-md-2" href="{url op="view" page="issue" path=$issue->getBestIssueId()}">
 					<img src="{$issueCover|escape}"{if $issue->getLocalizedCoverImageAltText() != ''} alt="{$issue->getLocalizedCoverImageAltText()|escape}"{/if} class="img-fluid">
 				</a>
 			{/if}


### PR DESCRIPTION
This closes #53 by adding the page argument to the url builder in the issue_toc.tpl, which is used by the journal index page to display the current issue. 