### PR TITLE
Display issue DOI on issue detail pages

### DIFF
--- a/resources/less/objects/issue_toc.less
+++ b/resources/less/objects/issue_toc.less
@@ -7,6 +7,11 @@
 	& .container {
 		min-height: 20vh;
 	}
+
+	.pub_id a {
+		color: #fff;
+		padding-left: 5px;
+	}
 }
 
 .issue.issue__empty {

--- a/templates/frontend/objects/issue_toc.tpl
+++ b/templates/frontend/objects/issue_toc.tpl
@@ -47,7 +47,26 @@
             	{$smarty.capture.issueMetadata}
 			</h2>
 		{/if}
-
+            {foreach from=$pubIdPlugins item=pubIdPlugin}
+					{assign var=pubId value=$issue->getStoredPubId($pubIdPlugin->getPubIdType())}
+					{if $pubId}
+						{assign var="doiUrl" value=$pubIdPlugin->getResolvingURL($currentJournal->getId(), $pubId)|escape}
+						<div class="pub_id {$pubIdPlugin->getPubIdType()|escape}">
+                                        <span class="type">
+                                                {$pubIdPlugin->getPubIdDisplayType()|escape}:
+                                        </span>
+							<span class="id">
+                                                {if $doiUrl}
+													<a href="{$doiUrl|escape}">
+                                                                {$doiUrl}
+                                                        </a>
+												{else}
+													{$pubId}
+												{/if}
+                                        </span>
+						</div>
+					{/if}
+				{/foreach}
 		{if $issue->getDatePublished()}
 			<p class="issue__meta">{translate key="plugins.themes.immersion.issue.published"} {$issue->getDatePublished()|date_format:$dateFormatLong}</p>
 		{/if}

--- a/templates/frontend/objects/issue_toc.tpl
+++ b/templates/frontend/objects/issue_toc.tpl
@@ -47,7 +47,8 @@
             	{$smarty.capture.issueMetadata}
 			</h2>
 		{/if}
-            {foreach from=$pubIdPlugins item=pubIdPlugin}
+
+		{foreach from=$pubIdPlugins item=pubIdPlugin}
 					{assign var=pubId value=$issue->getStoredPubId($pubIdPlugin->getPubIdType())}
 					{if $pubId}
 						{assign var="doiUrl" value=$pubIdPlugin->getResolvingURL($currentJournal->getId(), $pubId)|escape}
@@ -67,6 +68,7 @@
 						</div>
 					{/if}
 				{/foreach}
+
 		{if $issue->getDatePublished()}
 			<p class="issue__meta">{translate key="plugins.themes.immersion.issue.published"} {$issue->getDatePublished()|date_format:$dateFormatLong}</p>
 		{/if}


### PR DESCRIPTION
This closes #56 by adding the doi/pub id above the issue publication date. Tested in OJS 3.2.1.1. In order to test, will need to recompile `.less` files. 