### PR TITLE
Changed plus/minus to right arrow/down arrow to show affiliation

### DIFF
--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -108,8 +108,9 @@
 								{if $authorInfo}
 									<a class="author-string__href" href="#author-{$authorStringKey+1}">
 										<span>{$authorString->getFullName()|escape}</span>
-										<sup class="author-symbol author-plus">&plus;</sup>
-										<sup class="author-symbol author-minus hidden">&minus;</sup>
+										<span class="author-symbol author-plus">&ThinSpace;&rtri; </span>
+										<span class="author-symbol author-minus hidden">&ThinSpace;&dtri;</span>
+
 									</a>
 									{else}
 									<span class="author-string_href-none">

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -110,7 +110,6 @@
 										<span>{$authorString->getFullName()|escape}</span>
 										<sup class="author-symbol author-plus">&ThinSpace;&rtrif;</sup>
 										<sup class="author-symbol author-minus hidden">&ThinSpace;&dtrif;</sup>
-
 									</a>
 									{else}
 									<span class="author-string_href-none">

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -108,8 +108,8 @@
 								{if $authorInfo}
 									<a class="author-string__href" href="#author-{$authorStringKey+1}">
 										<span>{$authorString->getFullName()|escape}</span>
-										<span class="author-symbol author-plus">&ThinSpace;&rtri; </span>
-										<span class="author-symbol author-minus hidden">&ThinSpace;&dtri;</span>
+										<span class="author-symbol author-plus">&ThinSpace;&rtrif;</span>
+										<span class="author-symbol author-minus hidden">&ThinSpace;&dtrif;</span>
 
 									</a>
 									{else}

--- a/templates/frontend/objects/article_details.tpl
+++ b/templates/frontend/objects/article_details.tpl
@@ -108,8 +108,8 @@
 								{if $authorInfo}
 									<a class="author-string__href" href="#author-{$authorStringKey+1}">
 										<span>{$authorString->getFullName()|escape}</span>
-										<span class="author-symbol author-plus">&ThinSpace;&rtrif;</span>
-										<span class="author-symbol author-minus hidden">&ThinSpace;&dtrif;</span>
+										<sup class="author-symbol author-plus">&ThinSpace;&rtrif;</sup>
+										<sup class="author-symbol author-minus hidden">&ThinSpace;&dtrif;</sup>
 
 									</a>
 									{else}


### PR DESCRIPTION
This closes #59. This is just the alternative symbols we used to avoid potential confusion where the + as superscript after a name may seem to indicate that an author is deceased. I used a thin space between the name and the symbol for the sake of expediency, but you may prefer spacing be adjusted with a style rule. Example below:

<img width="764" alt="Screen Shot 2020-12-11 at 1 25 23 PM" src="https://user-images.githubusercontent.com/47127862/101940377-646dc680-3bb4-11eb-93a3-04af9d09880f.png">
<img width="763" alt="Screen Shot 2020-12-11 at 1 25 31 PM" src="https://user-images.githubusercontent.com/47127862/101940379-646dc680-3bb4-11eb-9967-ec864fa68e08.png">