### PR TITLE
Add the option to show abstracts on the issue page

### DIFF
--- a/ImmersionThemePlugin.inc.php
+++ b/ImmersionThemePlugin.inc.php
@@ -75,6 +75,27 @@ class ImmersionThemePlugin extends ThemePlugin {
 			'default' => '#000',
 		));
 
+		$this->addOption('abstractsOnIssuePage', 'FieldOptions', [
+			'type' => 'radio',
+			'label' => __('plugins.themes.immersion.option.abstractsOnIssuePage.label'),
+			'description' => __('plugins.themes.immersion.option.abstractsOnIssuePage.description'),
+			'tooltip' => __('plugins.themes.immersion.option.abstractsOnIssuePage.tooltip'),
+			'options' => [
+				[
+					'value' => 'noAbstracts',
+					'label' => __('plugins.themes.immersion.option.abstractsOnIssuePage.noAbstracts'),
+				],
+				[
+					'value' => 'shortAbstracts',
+					'label' => __('plugins.themes.immersion.option.abstractsOnIssuePage.shortAbstracts'),
+				],
+				[
+					'value' => 'fullAbstracts',
+					'label' => __('plugins.themes.immersion.option.abstractsOnIssuePage.fullAbstracts'),
+				],
+			],
+			'default' => 'noAbstracts',
+		]);
 
 		// Additional data to the templates
 		HookRegistry::register ('TemplateManager::display', array($this, 'addIssueTemplateData'));
@@ -209,7 +230,8 @@ class ImmersionThemePlugin extends ThemePlugin {
 
 		$templateMgr->assign(array(
 			'publishedSubmissions' => $publishedSubmissionsInSection,
-			'lastSectionColor' => $lastSectionColor
+			'lastSectionColor' => $lastSectionColor,
+			'showAbstractsOnIssuePage' => $this->getOption('abstractsOnIssuePage')
 		));
 	}
 

--- a/ImmersionThemePlugin.inc.php
+++ b/ImmersionThemePlugin.inc.php
@@ -489,7 +489,7 @@ class ImmersionThemePlugin extends ThemePlugin {
 	}
 
 	/**
-	 * Get all defined sectin colors indexed by 'issueId_sectionId'
+	 * Get all defined section colors indexed by 'issueId_sectionId'
 	 */
 	public function addStyles($hookname, $args) {
 

--- a/ImmersionThemePlugin.inc.php
+++ b/ImmersionThemePlugin.inc.php
@@ -86,8 +86,8 @@ class ImmersionThemePlugin extends ThemePlugin {
 					'label' => __('plugins.themes.immersion.option.abstractsOnIssuePage.noAbstracts'),
 				],
 				[
-					'value' => 'shortAbstracts',
-					'label' => __('plugins.themes.immersion.option.abstractsOnIssuePage.shortAbstracts'),
+					'value' => 'fadeoutAbstracts',
+					'label' => __('plugins.themes.immersion.option.abstractsOnIssuePage.fadeoutAbstracts'),
 				],
 				[
 					'value' => 'fullAbstracts',

--- a/ImmersionThemePlugin.inc.php
+++ b/ImmersionThemePlugin.inc.php
@@ -502,7 +502,7 @@ class ImmersionThemePlugin extends ThemePlugin {
 		// For the abstract fade-out effect we require a css class for each section color
 		$cssOutput = '';
 		$issue = $templateMgr->getTemplateVars('issue');
-		if ($issue) {
+		if ($issue && $issue->getData('immersionSectionColor')) {
 			foreach ($issue->getData('immersionSectionColor') as $sectionIndex => $sectionColor) {
 					$cssOutput .= ".article__abstract-fadeout-{$sectionIndex}::after {\n";
 					$cssOutput .= "  background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, {$sectionColor} 100%);\n";

--- a/ImmersionThemePlugin.inc.php
+++ b/ImmersionThemePlugin.inc.php
@@ -25,6 +25,15 @@ class ImmersionThemePlugin extends ThemePlugin {
 		// Styles for HTML galleys
 		$this->addStyle('htmlGalley', 'templates/plugins/generic/htmlArticleGalley/css/default.css', array('contexts' => 'htmlGalley'));
 
+		// For the abstract fade-out effect we require a css class for each section color
+		$cssOutput = '';
+		foreach ($this->getAllSectionColors() as $colorIndex => $sectionColor) {
+				$cssOutput .= ".article__abstract-fadeout-{$colorIndex}::after {\n";
+				$cssOutput .= "  background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, {$sectionColor} 100%);\n";
+				$cssOutput .= "}\n\n";
+		}
+		$this->addStyle('fadeout', $cssOutput, ['inline' => true]);
+		
 		// Adding scripts (JQuery, Popper, Bootstrap, JQuery UI, Tag-it, Theme's JS)
 		$this->addScript('app-js', 'resources/dist/app.min.js');
 
@@ -481,5 +490,25 @@ class ImmersionThemePlugin extends ThemePlugin {
 			'boolEmbeddedCss' => $boolEmbeddedCss,
 			'themePath' => $request->getBaseUrl() . "/" . $this->getPluginPath(),
 		));
+	}
+
+	/**
+	 * Get all defined sectin colors indexed by 'issueId_sectionId'
+	 */
+	public function getAllSectionColors() {
+		$issueDao = DAORegistry::getDAO('IssueDAO');
+		$issues = $issueDao->getPublishedIssues(Application::get()->getRequest()->getContext()->getId());
+
+		$immersionSectionColors = [];
+		while ($issue = $issues->next()) {
+			$immersionSectionColors[$issue->getId()] = $issue->getData('immersionSectionColor');
+		}
+
+		return array_reduce(array_keys($immersionSectionColors), function($carry, $outerKey) use ($immersionSectionColors) {
+			foreach ($immersionSectionColors[$outerKey] as $innerKey => $value) {
+				$carry[$outerKey . '_' . $innerKey] = $value;
+			}
+			return $carry;
+		}, []);
 	}
 }

--- a/ImmersionThemePlugin.inc.php
+++ b/ImmersionThemePlugin.inc.php
@@ -502,20 +502,22 @@ class ImmersionThemePlugin extends ThemePlugin {
 		// For the abstract fade-out effect we require a css class for each section color
 		$cssOutput = '';
 		$issue = $templateMgr->getTemplateVars('issue');
-		foreach ($issue->getData('immersionSectionColor') as $sectionIndex => $sectionColor) {
-				$cssOutput .= ".article__abstract-fadeout-{$sectionIndex}::after {\n";
-				$cssOutput .= "  background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, {$sectionColor} 100%);\n";
-				$cssOutput .= "}\n\n";
-		}
+		if ($issue) {
+			foreach ($issue->getData('immersionSectionColor') as $sectionIndex => $sectionColor) {
+					$cssOutput .= ".article__abstract-fadeout-{$sectionIndex}::after {\n";
+					$cssOutput .= "  background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, {$sectionColor} 100%);\n";
+					$cssOutput .= "}\n\n";
+			}
 
-		$templateMgr->addStyleSheet(
-			'fadeout',
-			$cssOutput,
-			[
-				'contexts' => 'frontend',
-				'inline' => true,
-				'priority' => STYLE_SEQUENCE_LAST,
-			]
-		);
+			$templateMgr->addStyleSheet(
+				'fadeout',
+				$cssOutput,
+				[
+					'contexts' => 'frontend',
+					'inline' => true,
+					'priority' => STYLE_SEQUENCE_LAST,
+				]
+			);
+		}
 	}
 }

--- a/locale/de_DE/locale.po
+++ b/locale/de_DE/locale.po
@@ -107,3 +107,21 @@ msgstr "Beschreibung der Zeitschrift anzeigen"
 
 msgid "plugins.themes.immersion.about.journal"
 msgstr "Über die Zeitschrift"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.label"
+msgstr "Zeige Artikel-Abstracts auf der Ausgabenseite"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.description"
+msgstr "Wähle wie die Artikel-Abstracts auf der Ausgabenseite dargestellt werden sollen"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.noAbstracts"
+msgstr "Zeige keine Artikel-Abstracts"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.fadeoutAbstracts"
+msgstr "Zeige den Anfang der Artikel-Abstract (mit Ausblendeffekt)"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.fullAbstracts"
+msgstr "Zeige die gesamten Artikel-Abstract"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.tooltip"
+msgstr "Um bei der der Auswahl \"Zeige den Anfang der Artikel-Abstract\" die Höhe der sichtbaren Artikel-Abstracts festzulegen setzte die Höhe im Journal Stylesheet über die CSS-Klasse \".article__abstract-fade {height = xxxpx;}\"."

--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -110,11 +110,11 @@ msgstr "Select how to show article abstracts on issue pages"
 msgid "plugins.themes.immersion.option.abstractsOnIssuePage.noAbstracts"
 msgstr "Do not show abstracts"
 
-msgid "plugins.themes.immersion.option.abstractsOnIssuePage.shortAbstracts"
-msgstr "Show shortend abstracts"
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.fadeoutAbstracts"
+msgstr "Show partial abstracts (with fade-out effect)"
 
 msgid "plugins.themes.immersion.option.abstractsOnIssuePage.fullAbstracts"
 msgstr "Show full abstracts"
 
 msgid "plugins.themes.immersion.option.abstractsOnIssuePage.tooltip"
-msgstr "To adjust the height of the abstract visible when selecting \"shortend abstracts\" set the css class \".article__abstract-shortend {height = xxxpx;}\" in the journal stylesheet."
+msgstr "To adjust the height of the abstract visible when selecting \"partial abstracts\" set the css class \".article__abstract-fade {height = xxxpx;}\" in the journal stylesheet."

--- a/locale/en_US/locale.po
+++ b/locale/en_US/locale.po
@@ -100,3 +100,21 @@ msgstr "Journal description background"
 
 msgid "plugins.themes.immersion.options.journalDescriptionColour.description"
 msgstr "Background colour for the journal description section on the journal home page"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.label"
+msgstr "Show article abstracts on issue page"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.description"
+msgstr "Select how to show article abstracts on issue pages"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.noAbstracts"
+msgstr "Do not show abstracts"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.shortAbstracts"
+msgstr "Show shortend abstracts"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.fullAbstracts"
+msgstr "Show full abstracts"
+
+msgid "plugins.themes.immersion.option.abstractsOnIssuePage.tooltip"
+msgstr "To adjust the height of the abstract visible when selecting \"shortend abstracts\" set the css class \".article__abstract-shortend {height = xxxpx;}\" in the journal stylesheet."

--- a/resources/less/objects/article_summary.less
+++ b/resources/less/objects/article_summary.less
@@ -39,6 +39,7 @@
 .article__abstract-fadeout::after {
 	content: '';
 	position: absolute;
+	pointer-events: none;
 	bottom: 0;
 	left: 0;
 	right: 0;

--- a/resources/less/objects/article_summary.less
+++ b/resources/less/objects/article_summary.less
@@ -43,5 +43,4 @@
 	left: 0;
 	right: 0;
 	height: 30%; /* Height of the fade effect */
-	background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
 }

--- a/resources/less/objects/article_summary.less
+++ b/resources/less/objects/article_summary.less
@@ -29,3 +29,19 @@
 .article__btn-group li {
 	display: inline-block;
 }
+
+.article__abstract-shortend {
+	position: relative;
+	height: 400px;
+	overflow: hidden;
+}
+
+.article__abstract-shortend::after {
+	content: '';
+	position: absolute;
+	bottom: 0; /* Position at the bottom */
+	left: 0;
+	right: 0;
+	height: 30px; /* Height of the fade effect */
+	background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%); /* Adjust colors as needed */
+}

--- a/resources/less/objects/article_summary.less
+++ b/resources/less/objects/article_summary.less
@@ -30,18 +30,18 @@
 	display: inline-block;
 }
 
-.article__abstract-shortend {
+.article__abstract-fadeout {
 	position: relative;
 	height: 400px;
 	overflow: hidden;
 }
 
-.article__abstract-shortend::after {
+.article__abstract-fadeout::after {
 	content: '';
 	position: absolute;
-	bottom: 0; /* Position at the bottom */
+	bottom: 0;
 	left: 0;
 	right: 0;
-	height: 30px; /* Height of the fade effect */
-	background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%); /* Adjust colors as needed */
+	height: 30%; /* Height of the fade effect */
+	background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
 }

--- a/resources/less/objects/article_summary.less
+++ b/resources/less/objects/article_summary.less
@@ -43,4 +43,5 @@
 	left: 0;
 	right: 0;
 	height: 30%; /* Height of the fade effect */
+	background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
 }

--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -37,7 +37,7 @@
 				</figure>
 			</div>
 		{/if}
-		<div class="col-md-{if $requestedOp === "search"}12{else}8{/if}{if !$coverImageUrl} offset-md-4{/if} {if $showAbstractsOnIssuePage === 'fadeoutAbstracts'}article__abstract-fadeout article__abstract-fadeout-{substr($immersionColorPick, 1)}{/if}">
+		<div class="col-md-{if $requestedOp === "search"}12{else}8{/if}{if !$coverImageUrl} offset-md-4{/if} {if $showAbstractsOnIssuePage === 'fadeoutAbstracts'}article__abstract-fadeout article__abstract-fadeout-{$issue->getId()}_{$section.section->getId()}{/if}">
 			{if $showAuthor}
 				<p class="article__meta">{$article->getAuthorString()|escape}</p>
 			{/if}
@@ -71,13 +71,6 @@
 			{/if}
 
 			{if $showAbstractsOnIssuePage !== 'noAbstracts'}
-				{if $immersionColorPick} 
-					<style>
-						.article__abstract-fadeout-{substr($immersionColorPick, 1)}::after {
-							background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, {$immersionColorPick} 100%);
-						}
-					</style>
-				{/if}
 				{$article->getLocalizedAbstract()|strip_unsafe_html}
 			{/if}
 		</div>

--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -36,7 +36,7 @@
 				</figure>
 			</div>
 		{/if}
-		<div class="col-md-{if $requestedOp === "search"}12{else}8{/if}{if !$coverImageUrl} offset-md-4{/if}">
+		<div class="col-md-{if $requestedOp === "search"}12{else}8{/if}{if !$coverImageUrl} offset-md-4{/if} {if $showAbstractsOnIssuePage === 'shortAbstracts'}article__abstract-shortend{/if}">
 			{if $showAuthor}
 				<p class="article__meta">{$article->getAuthorString()|escape}</p>
 			{/if}
@@ -67,6 +67,10 @@
 						</li>
 					{/foreach}
 				</ul>
+			{/if}
+
+			{if $showAbstractsOnIssuePage !== 'noAbstracts'}
+				{$article->getLocalizedAbstract()|strip_unsafe_html}
 			{/if}
 		</div>
 

--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -37,7 +37,7 @@
 				</figure>
 			</div>
 		{/if}
-		<div class="col-md-{if $requestedOp === "search"}12{else}8{/if}{if !$coverImageUrl} offset-md-4{/if} {if $showAbstractsOnIssuePage === 'fadeoutAbstracts'}article__abstract-fadeout article__abstract-fadeout-{$issue->getId()}_{$section.section->getId()}{/if}">
+		<div class="col-md-{if $requestedOp === "search"}12{else}8{/if}{if !$coverImageUrl} offset-md-4{/if} {if $showAbstractsOnIssuePage === 'fadeoutAbstracts'}article__abstract-fadeout article__abstract-fadeout-{$section.section->getId()}{/if}">
 			{if $showAuthor}
 				<p class="article__meta">{$article->getAuthorString()|escape}</p>
 			{/if}

--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -13,6 +13,7 @@
  * @uses $showDatePublished bool Show the date this article was published?
  * @uses $hideGalleys bool Hide the article galleys for this article?
  * @uses $primaryGenreIds array List of file genre ids for primary file types
+ * @uses $showAbstractsOnIssuePage string Mode of abstarct visibility
  *}
 {assign var=articlePath value=$article->getBestId()}
 
@@ -36,7 +37,7 @@
 				</figure>
 			</div>
 		{/if}
-		<div class="col-md-{if $requestedOp === "search"}12{else}8{/if}{if !$coverImageUrl} offset-md-4{/if} {if $showAbstractsOnIssuePage === 'shortAbstracts'}article__abstract-shortend{/if}">
+		<div class="col-md-{if $requestedOp === "search"}12{else}8{/if}{if !$coverImageUrl} offset-md-4{/if} {if $showAbstractsOnIssuePage === 'fadeoutAbstracts'}article__abstract-fadeout{/if}">
 			{if $showAuthor}
 				<p class="article__meta">{$article->getAuthorString()|escape}</p>
 			{/if}
@@ -70,6 +71,13 @@
 			{/if}
 
 			{if $showAbstractsOnIssuePage !== 'noAbstracts'}
+				{if $immersionColorPick} 
+					<style>
+						.article__abstract-fadeout::after {
+							background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, {$immersionColorPick} 100%);
+						}
+					</style>
+				{/if}
 				{$article->getLocalizedAbstract()|strip_unsafe_html}
 			{/if}
 		</div>

--- a/templates/frontend/objects/article_summary.tpl
+++ b/templates/frontend/objects/article_summary.tpl
@@ -37,7 +37,7 @@
 				</figure>
 			</div>
 		{/if}
-		<div class="col-md-{if $requestedOp === "search"}12{else}8{/if}{if !$coverImageUrl} offset-md-4{/if} {if $showAbstractsOnIssuePage === 'fadeoutAbstracts'}article__abstract-fadeout{/if}">
+		<div class="col-md-{if $requestedOp === "search"}12{else}8{/if}{if !$coverImageUrl} offset-md-4{/if} {if $showAbstractsOnIssuePage === 'fadeoutAbstracts'}article__abstract-fadeout article__abstract-fadeout-{substr($immersionColorPick, 1)}{/if}">
 			{if $showAuthor}
 				<p class="article__meta">{$article->getAuthorString()|escape}</p>
 			{/if}
@@ -73,7 +73,7 @@
 			{if $showAbstractsOnIssuePage !== 'noAbstracts'}
 				{if $immersionColorPick} 
 					<style>
-						.article__abstract-fadeout::after {
+						.article__abstract-fadeout-{substr($immersionColorPick, 1)}::after {
 							background: linear-gradient(to bottom, rgba(255, 255, 255, 0) 0%, {$immersionColorPick} 100%);
 						}
 					</style>

--- a/version.xml
+++ b/version.xml
@@ -23,10 +23,10 @@
 	    Valid: 1.0.2.3, 0.1.4.0
 		Invalid: 1.0, v1.0.4, 1.0.0.0b
 	-->
-	<release>1.1.2.0</release>
+	<release>1.1.1.0</release>
 
 	<!-- The date of the latest version -->
-	<date>2025-1-15</date>
+	<date>2022-10-28</date>
 
 	<!-- This should always be 1 -->
 	<lazy-load>1</lazy-load>

--- a/version.xml
+++ b/version.xml
@@ -23,10 +23,10 @@
 	    Valid: 1.0.2.3, 0.1.4.0
 		Invalid: 1.0, v1.0.4, 1.0.0.0b
 	-->
-	<release>1.1.1.0</release>
+	<release>1.1.2.0</release>
 
 	<!-- The date of the latest version -->
-	<date>2022-10-28</date>
+	<date>2025-1-15</date>
 
 	<!-- This should always be 1 -->
 	<lazy-load>1</lazy-load>


### PR DESCRIPTION
Hi @Vitaliy-1 ,

as discussed here my PR to add a feature to show abstarcts on the issue page.

Currently there is a test installation available at [http://ojs-dev-01.cedis.fu-berlin.de/index.php/tfj](http://ojs-dev-01.cedis.fu-berlin.de/index.php/tfj) where you can see the frontend effect.

In the backend it looks like this:

![grafik](https://github.com/user-attachments/assets/d9b9213a-798d-491f-ae31-eacfc95cd8e6)

This PR is for 3.3. I can prepare a 3.4 PR in a next step.

P.S.: Naturally I am not able to provide translations for all supported languages. I just add DE and EN.

Best wishes,
Ronald