### PR TITLE
Port of PR to fix a fatal error on constant without namespace

### DIFF
--- a/templates/frontend/components/editLink.tpl
+++ b/templates/frontend/components/editLink.tpl
@@ -15,7 +15,7 @@
  * @uses SectionTitleKey string A key that must be translated to get the
  *       $sectionTitle
  *}
-{if in_array(ROLE_ID_MANAGER, (array) $userRoles)}
+{if in_array(\PKP\security\Role::ROLE_ID_MANAGER, (array) $userRoles)}
 
 	{* Render the $sectionTitle if we only have a translation key *}
 	{if $sectionTitleKey}


### PR DESCRIPTION
This is a port of a fix for an error that has been identified and fixed in other PKP themes: https://github.com/pkp/healthSciences/issues/244. The error log is similar to that of the Health Sciences theme, and the bug fix in that PR resolved the problem in our journal.

> [Mon Jul 14 13:36:34.805407 2025] [php:error] [pid 31874:tid 31874] [client 24.243.149.212:51003] PHP Fatal error: Uncaught Error: Undefined constant "ROLE_ID_MANAGER" in /ebs/ojs/cache/t_compile/7035807316a69f2730f846ce1fb4ed46b5bbbbd8^e3c52a8a644dae8ad3689fcdc7091f2c0eae2ce2_0.app.frontendcomponentseditLink.tpl.php:24\nStack trace:\n#0 /ebs/ojs/lib/pkp/lib/vendor/smarty/smarty/libs/sysplugins/smarty_template_resource_base.php(123): content_68559e26a8bad9_68657638(Object(Smarty_Internal_Template))\n#1 /ebs/ojs/lib/pkp/lib/vendor/smarty/smarty/libs/sysplugins/smarty_template_compiled.php(114): Smarty_Template_Resource_Base->getRenderedTemplateCode(Object(Smarty_Internal_Template))\n#2 /ebs/ojs/lib/pkp/lib/vendor/smarty/smarty/libs/sysplugins/smarty_internal_template.php(217): Smarty_Template_Compiled->render(Object(Smarty_Internal_Template))\n#3 /ebs/ojs/lib/pkp/lib/vendor/smarty/smarty/libs/sysplugins/smarty_internal_template.php(386): Smarty_Internal_Template->render()\n#4 /ebs/ojs/cache/t_compile/7035807316a69f2730f846ce1fb4ed46b5bbbbd8^f59ba25f4aae6a7b19033686947ff5a7d2a098e0_0.app.frontendpagessubmissions.tpl.php(73): Smarty_Internal_Template->_subTemplateRender('app:frontend/co…', NULL, '7035807316a69f2…', 0, 3600, Array, 0, false)\n#5 /ebs/ojs/lib/pkp/lib/vendor/smarty/smarty/libs/sysplugins/smarty_template_resource_base.php(123): content_68559e269af9c5_71623587(Object(Smarty_Internal_Template))\n#6 /ebs/ojs/lib/pkp/lib/vendor/smarty/smarty/libs/sysplugins/smarty_template_compiled.php(114): Smarty_Template_Resource_Base->getRenderedTemplateCode(Object(Smarty_Internal_Template))\n#7 /ebs/ojs/lib/pkp/lib/vendor/smarty/smarty/libs/sysplugins/smarty_internal_template.php(217): Smarty_Template_Compiled->render(Object(Smarty_Internal_Template))\n#8 /ebs/ojs/lib/pkp/lib/vendor/smarty/smarty/libs/sysplugins/smarty_internal_templatebase.php(238): Smarty_Internal_Template->render(false, 1)\n#9 /ebs/ojs/lib/pkp/lib/vendor/smarty/smarty/libs/sysplugins/smarty_internal_templatebase.php(134): Smarty_Internal_TemplateBase->_execute(Object(Smarty_Internal_Template), NULL, '7035807316a69f2…', NULL, 1)\n#10 /ebs/ojs/lib/pkp/classes/template/PKPTemplateManager.php(1368): Smarty_Internal_TemplateBase->display('frontend/pages/…', NULL, '7035807316a69f2…', NULL)\n#11 /ebs/ojs/lib/pkp/pages/about/AboutContextHandler.php(99): PKP\\template\\PKPTemplateManager->display('frontend/pages/…')\n#12 [internal function]: PKP\\pages\\about\\AboutContextHandler->submissions(Array, Object(APP\\core\\Request))\n#13 /ebs/ojs/lib/pkp/classes/core/PKPRouter.php(334): call_user_func(Array, Array, Object(APP\\core\\Request))\n#14 /ebs/ojs/lib/pkp/classes/core/PKPPageRouter.php(277): PKP\\core\\PKPRouter->_authorizeInitializeAndCallRequest(Array, Object(APP\\core\\Request), Array, false)\n#15 /ebs/ojs/lib/pkp/classes/core/Dispatcher.php(165): PKP\\core\\PKPPageRouter->route(Object(APP\\core\\Request))\n#16 /ebs/ojs/lib/pkp/classes/core/PKPApplication.php(388): PKP\\core\\Dispatcher->dispatch(Object(APP\\core\\Request))\n#17 /ebs/ojs/index.php(21): PKP\\core\\PKPApplication->execute()\n#18 {main}\n thrown in /ebs/ojs/cache/t_compile/7035807316a69f2730f846ce1fb4ed46b5bbbbd8^e3c52a8a644dae8ad3689fcdc7091f2c0eae2ce2_0.app.frontendcomponentseditLink.tpl.php on line 24, referer: 