### PR TITLE
Fix missing form close

### DIFF
--- a/templates/frontend/pages/userRegister.tpl
+++ b/templates/frontend/pages/userRegister.tpl
@@ -153,8 +153,9 @@
 					{translate key="user.register"}
 				</button>
 
-			{capture assign="rolesProfileUrl"}{url page="user" op="profile" path="roles"}{/capture}
-			<a href="{url page="login" source=$rolesProfileUrl}" class="login">{translate key="user.login"}</a>
+				{capture assign="rolesProfileUrl"}{url page="user" op="profile" path="roles"}{/capture}
+				<a href="{url page="login" source=$rolesProfileUrl}" class="login">{translate key="user.login"}</a>
+			</form>
 		</div>
 	</div><!-- row -->
 </main><!-- page container -->


### PR DESCRIPTION
The user register <form> was not properly closed. This was subsequently leading to issues where e.g. newsletter subscribe forms are used in custom blocks in the sidebar loaded via the footer.tpl. User registration was blocked completely in this context due to missing required fields.