### PR TITLE
pkp/immersion#125 Language switcher does not support keyboard

### DIFF
--- a/templates/frontend/components/languageSwitcher.tpl
+++ b/templates/frontend/components/languageSwitcher.tpl
@@ -14,7 +14,7 @@
 
 <ul id="{$id|escape}" class="language-toggle nav">
 	<li class="nav-item dropdown">
-		<a class="main-header__lang-link dropdown-toggle" id="languageToggleMenu{$id|escape}" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+		<a href="#" role="button" tabindex="0" class="main-header__lang-link dropdown-toggle" id="languageToggleMenu{$id|escape}" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 			<span class="visually-hidden">{translate key="plugins.themes.immersion.language.toggle"}</span>
 			{$languageToggleLocales[$currentLocale]|escape}
 		</a>


### PR DESCRIPTION
Fix the lack of support to activate the language switcher using keyboard-only navigation. I've added `role="button"` and an empty `href="#"` to create focus for keyboard interaction.
Issue: https://github.com/pkp/immersion/issues/125